### PR TITLE
allow for source transformations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,10 @@ const InlineSvgComponent = {
             type: String,
             required: true,
         },
+        transformSource: {
+            type: Function,
+            default: (svg) => svg,
+        },
     },
     data() {
         return {
@@ -104,11 +108,11 @@ const InlineSvgComponent = {
                 const request = new XMLHttpRequest();
                 request.open('GET', url, true);
 
-                request.onload = function requestOnload() {
+                request.onload = () => {
                     if (request.status >= 200 && request.status < 400) {
                         // Setup a parser to convert the response to text/xml in order for it to be manipulated and changed
                         const parser = new DOMParser();
-                        const result = parser.parseFromString(request.responseText, 'text/xml');
+                        const result = parser.parseFromString(this.transformSource(request.responseText), 'text/xml');
                         const svgEl = result.getElementsByTagName('svg')[0];
                         resolve(svgEl);
                     } else {


### PR DESCRIPTION
This change enables the user to transform the svg before it's processed by the component.

```
<inline-svg :transformSource="transform" ... />
```

This is useful if you want to modify the svg (e.g. cleanup via SVGO) or thelike.
This removes all `titles` and `defs` from the loaded svg:

```
const transform = (source) => {
	const parser = new DOMParser()
	const result = parser.parseFromString(source, 'text/xml')
	const svgEl = result.getElementsByTagName('svg')[0]
	Array.prototype.forEach.call(svgEl.getElementsByTagName('defs'), child => svgEl.removeChild(child))
	Array.prototype.forEach.call(svgEl.getElementsByTagName('title'), child => svgEl.removeChild(child))
	return svgEl.outerHTML
}
```