### PR TITLE
Add `browser` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Replace SVG images with inline SVG element",
   "main": "dist/vue-inline-svg.js",
   "module": "src/index.js",
+  "browser": "dist/vue-inline-svg.js",
   "unpkg": "dist/vue-inline-svg.min.js",
   "scripts": {
     "build": "rollup -c rollup.conf.js",


### PR DESCRIPTION
Fixes #14

With this, the bundler should be able to pick the right file when building for the web. This way you don't have to ask babel loader/plugin to transpile this dependency.