### PR TITLE
Add "title" prop to set/overwrite SVG title

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Loaded SVGs are cached so it will not make network request twice.
 - [Usage](#usage)
   - [props](#props)
     - [src](#--src)
+    - [title](#--title)
     - [transformSource](#--transformsource)
   - [SVG attributes](#svg-attributes)
   - [events](#events)
@@ -109,6 +110,13 @@ Note: if you use vue-loader assets or vue-cli, then paths like '../assets/my.svg
 Learn more:
 - https://vue-loader.vuejs.org/guide/asset-url.html#transform-rules
 - https://cli.vuejs.org/guide/html-and-static-assets.html#static-assets-handling
+
+#### - `title`
+Sets/overwrites the title of the SVG
+
+```
+<inline-svg :src="image.svg" :title="My Image"/>
+```
 
 #### - `transformSource`
 Function to transform SVG source

--- a/src/index.js
+++ b/src/index.js
@@ -89,6 +89,9 @@ const InlineSvgComponent = {
                     for (let i = attrs.length - 1; i >= 0; i--) {
                         this.svgAttrs[attrs[i].name] = attrs[i].value;
                     }
+                    if (this.title) {
+                        this.setTitle(svg);
+                    }
                     // copy inner html
                     this.svgContent = svg.innerHTML;
                     // render svg element
@@ -125,9 +128,6 @@ const InlineSvgComponent = {
                             let svgEl = result.getElementsByTagName('svg')[0];
                             if (svgEl) {
                                 svgEl = this.transformSource(svgEl);
-                                if (this.title) {
-                                    this.setTitle(svgEl);
-                                }
                                 resolve(svgEl);
                             } else {
                                 reject(new Error('Loaded file is not valid SVG"'));

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,9 @@ const InlineSvgComponent = {
             type: String,
             required: true,
         },
+        title: {
+            type: String,
+        },
         transformSource: {
             type: Function,
             default: (svg) => svg,
@@ -122,6 +125,9 @@ const InlineSvgComponent = {
                             let svgEl = result.getElementsByTagName('svg')[0];
                             if (svgEl) {
                                 svgEl = this.transformSource(svgEl);
+                                if (this.title) {
+                                    this.setTitle(svgEl);
+                                }
                                 resolve(svgEl);
                             } else {
                                 reject(new Error('Loaded file is not valid SVG"'));
@@ -137,6 +143,21 @@ const InlineSvgComponent = {
                 request.onerror = reject;
                 request.send();
             });
+        },
+
+        /**
+         * Create or edit the <title> element of a SVG
+         * @param {Object} svg
+         */
+        setTitle(svg) {
+            const titleTags = svg.getElementsByTagName('title');
+            if (titleTags.length) { // overwrite existing title
+                titleTags[0].innerHTML = this.title;
+            } else { // create a title element if one doesn't already exist
+                const titleEl = document.createElementNS('http://www.w3.org/2000/svg', 'title');
+                titleEl.innerHTML = this.title;
+                svg.appendChild(titleEl);
+            }
         },
     },
 };


### PR DESCRIPTION
Adds a `title` prop to allow setting the content of the SVG's `<title>` element. If the SVG already has a title, it will be overwritten with the value of the prop. Otherwise, a `<title>` is created and appended to the SVG.

Fixes #3 