### PR TITLE
Correct TypeScript definition for transformSource

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,7 +10,7 @@ import { VueConstructor, PluginFunction } from 'vue';
 interface InlineSvgProps {
     src: string;
     title: string;
-    transformSource: (svg: string) => string;
+    transformSource: (svg: SVGElement) => SVGElement;
     keepDuringLoading: boolean;
 }
 


### PR DESCRIPTION
The transformSource options requires and provides an SVGElement, not a string, as far as I understand